### PR TITLE
feat: allow custom permalinks

### DIFF
--- a/.cherry.cjs
+++ b/.cherry.cjs
@@ -2,7 +2,7 @@ const JS_FILES = '**/*.{js,jsx}'
 const TS_FILES = '**/*.{ts,tsx}'
 
 module.exports = {
-  project_name: 'fwuensche/cherry-cli',
+  project_name: 'cherrypush/cherry-cli',
   plugins: {
     // npmOutdated: {}, // TODO: this requires an active internet connection thus should not be used in tests
     loc: {},

--- a/README.md
+++ b/README.md
@@ -224,6 +224,24 @@ cherry_push:
       - main
 ```
 
+# Configuration
+
+## Permalink
+
+Especially if you're using Cherry in a GitLab project, you might want to setup custom permalinks for your metrics.
+
+You can do this by adding a `permalink` property to your configuration file, such as:
+
+```js
+// .cherry.js
+module.exports = {
+  project_name: 'cherrypush/cherry-cli',
+  permalink: ({ filePath, lineNumber }) =>
+    `https://gitlab.com/cherrypush/cherry-cli/blob/HEAD/${filePath}${lineNumber ? `#L${lineNumber}` : ''}`,
+  plugins: { eslint: {} },
+}
+```
+
 # Feedback 🙏
 
 Any further question or suggestion?

--- a/bin/commands/run.js
+++ b/bin/commands/run.js
@@ -47,7 +47,7 @@ export default function (program) {
         if (options.metric)
           displayedOccurrences = displayedOccurrences.filter((o) => options.metric.includes(o.metricName))
 
-        displayedOccurrences.forEach((occurrence) => console.log(`👉 ${occurrence.text}`))
+        displayedOccurrences.forEach((occurrence) => console.log(`👉 ${occurrence.text} (${occurrence.url})`))
         console.log('Total occurrences:', displayedOccurrences.length)
       } else console.table(sortObject(countByMetric(occurrences)))
 

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -1,10 +1,10 @@
-import axios from 'axios'
-import fs from 'fs'
-import _ from 'lodash'
-import { panic } from '../src/error.js'
 import Spinnies from 'spinnies'
+import _ from 'lodash'
+import axios from 'axios'
+import { buildRepoURL } from '../src/permalink.js'
+import fs from 'fs'
+import { panic } from '../src/error.js'
 import { v4 } from 'uuid'
-import { buildRepoURL } from '../src/github.js'
 
 export const spinnies = new Spinnies()
 

--- a/src/github.js
+++ b/src/github.js
@@ -1,4 +1,0 @@
-export const buildRepoURL = (projectName) => `https://github.com/${projectName}`
-
-export const buildPermalink = (projectName, path, lineNumber) =>
-  `${buildRepoURL(projectName)}/blob/HEAD/${path}${lineNumber ? `#L${lineNumber}` : ''}`

--- a/src/occurrences.js
+++ b/src/occurrences.js
@@ -2,7 +2,7 @@ import { executeWithTiming, warnsAboutLongRunningTasks } from './helpers/timer.j
 
 import Spinnies from 'spinnies'
 import _ from 'lodash'
-import { buildPermalink } from './github.js'
+import { buildPermalink } from './permalink.js'
 import eslint from './plugins/eslint.js'
 import jsCircularDependencies from './plugins/js_circular_dependencies.js'
 import jsUnimported from './plugins/js_unimported.js'
@@ -162,6 +162,7 @@ const withEmptyMetrics = (occurrences, metrics = []) => {
 
 export const findOccurrences = async ({ configuration, files, metricNames, codeOwners, quiet }) => {
   let metrics = configuration.metrics
+  const { project_name: projectName, permalink } = configuration
 
   // Prevent running all metrics if a subset is provided
   if (metricNames) metrics = metrics.filter(({ name }) => metricNames.includes(name))
@@ -181,7 +182,8 @@ export const findOccurrences = async ({ configuration, files, metricNames, codeO
     text,
     value,
     metricName,
-    url: url !== undefined ? url : filePath && buildPermalink(configuration.project_name, filePath, lineNumber),
+    // The url might have been provided by plugins or eval metrics
+    url: url !== undefined ? url : filePath && buildPermalink(permalink, projectName, filePath, lineNumber),
     owners: owners !== undefined ? owners : filePath && codeOwners.getOwners(filePath),
   }))
 

--- a/src/permalink.js
+++ b/src/permalink.js
@@ -1,0 +1,9 @@
+export const buildRepoURL = (projectName) => `https://github.com/${projectName}`
+
+export const buildPermalink = (permalink, projectName, filePath, lineNumber) => {
+  if (permalink) {
+    return permalink({ projectName, filePath, lineNumber })
+  }
+
+  return `${buildRepoURL(projectName)}/blob/HEAD/${filePath}${lineNumber ? `#L${lineNumber}` : ''}`
+}

--- a/src/permalink.js
+++ b/src/permalink.js
@@ -1,9 +1,7 @@
 export const buildRepoURL = (projectName) => `https://github.com/${projectName}`
 
 export const buildPermalink = (permalink, projectName, filePath, lineNumber) => {
-  if (permalink) {
-    return permalink({ projectName, filePath, lineNumber })
-  }
+  if (permalink) return permalink({ filePath, lineNumber })
 
   return `${buildRepoURL(projectName)}/blob/HEAD/${filePath}${lineNumber ? `#L${lineNumber}` : ''}`
 }

--- a/src/permalink.test.js
+++ b/src/permalink.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPermalink } from './permalink.js'
+
+describe('buildPermalink', () => {
+  it('builds a permalink with a custom function', () => {
+    const permalink = ({ projectName, filePath, lineNumber }) =>
+      `https://gitlab.com/${projectName}/blob/HEAD/${filePath}${lineNumber ? `#L${lineNumber}` : ''}`
+
+    const projectName = 'cherrypush/cherry-cli'
+    const filePath = 'src/permalink.js'
+    const lineNumber = 1
+
+    const result = buildPermalink(permalink, projectName, filePath, lineNumber)
+
+    expect(result).toBe('https://gitlab.com/cherrypush/cherry-cli/blob/HEAD/src/permalink.js#L1')
+  })
+})

--- a/src/permalink.test.js
+++ b/src/permalink.test.js
@@ -4,8 +4,8 @@ import { buildPermalink } from './permalink.js'
 
 describe('buildPermalink', () => {
   it('builds a permalink with a custom function', () => {
-    const permalink = ({ projectName, filePath, lineNumber }) =>
-      `https://gitlab.com/${projectName}/blob/HEAD/${filePath}${lineNumber ? `#L${lineNumber}` : ''}`
+    const permalink = ({ filePath, lineNumber }) =>
+      `https://gitlab.com/cherrypush/cherry-cli/blob/HEAD/${filePath}${lineNumber ? `#L${lineNumber}` : ''}`
 
     const projectName = 'cherrypush/cherry-cli'
     const filePath = 'src/permalink.js'

--- a/src/plugins/eslint.js
+++ b/src/plugins/eslint.js
@@ -27,6 +27,7 @@ const run = async () => {
         text: `${filePath}:${message.line}`,
         filePath: filePath,
         metricName: `[eslint] ${message.ruleId}`,
+        lineNumber: message.line,
       }))
     })
 }

--- a/test/plugins/eslint.test.js
+++ b/test/plugins/eslint.test.js
@@ -15,8 +15,13 @@ function testEslint() {
 }
 
 describe('eslint plugin', () => {
-  it('returns paths relative to the root of the project', async () => {
+  it('works', async () => {
     const { stdout } = await execAsync('node bin/cherry.js run --metric "[eslint] no-unused-vars"')
+
+    // Uses the relative path to the project root, containing the line number
     expect(stdout).toContain('👉 test/plugins/eslint.test.js:9')
+
+    // Builds the correct permalink, also containing the line number
+    expect(stdout).toContain('https://github.com/cherrypush/cherry-cli/blob/HEAD/test/plugins/eslint.test.js#L9')
   })
 })


### PR DESCRIPTION
You can now add the permalink option to your configuration: 

```js
  permalink: ({ filePath, lineNumber }) =>
    `https://github.com/cherrypush/cherry-cli/blob/HEAD/${filePath}${lineNumber ? `#L${lineNumber}` : ''}`,
```

It takes two params, filePath and lineNumber, which can be used to compose the url as you see fit.

Note, however, that the lineNumber might not always be present so you'll need to handle that accordingly.